### PR TITLE
Enable multiple applications deployment at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ jobs:
         with:
           qovery-organization-id: [YOUR_QOVERY_ORGANIZATION_ID]
           qovery-environment-id: [APPLICATION_QOVERY_ENVIRONMENT_ID]
-          qovery-application-id: [APPLICATION_QOVERY_APPLICATION_ID]
+          qovery-application-ids: [APPLICATION_QOVERY_APPLICATION_ID1,APPLICATION_QOVERY_APPLICATION_ID2] # Comma-separated string of IDs
           qovery-api-token: ${{secrets.QOVERY_API_TOKEN}}
 ```

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
   qovery-environment-id:
     description: 'Qovery environment ID'
     required: true
-  qovery-application-id:
-    description: 'Qovery application ID'
+  qovery-application-ids:
+    description: 'Qovery applications IDS'
     required: true
   qovery-api-token:
     description: 'Qovery API token'
@@ -29,5 +29,5 @@ runs:
   args:
     - ${{ inputs.qovery-organization-id }}
     - ${{ inputs.qovery-environment-id }}
-    - ${{ inputs.qovery-application-id }}
+    - ${{ inputs.qovery-application-ids }}
     - ${{ inputs.qovery-api-token }}

--- a/github-action/app/deploy_application.go
+++ b/github-action/app/deploy_application.go
@@ -9,7 +9,7 @@ import (
 	"github-action/pkg"
 )
 
-func DeployApplication(qoveryAPIToken string, qoveryApplicationID string, qoveryEnvironmentID string, applicationCommitID string) error {
+func DeployApplication(qoveryAPIToken string, qoveryApplicationIDS string, qoveryEnvironmentID string, applicationCommitID string) error {
 	qoveryAPIClient := pkg.NewQoveryAPIClient(
 		&http.Client{},
 		"https://api.qovery.com",
@@ -52,7 +52,7 @@ func DeployApplication(qoveryAPIToken string, qoveryApplicationID string, qovery
 	}
 
 	// Launching deployment
-	err := qoveryAPIClient.DeployApplication(pkg.Application{ID: qoveryApplicationID, CommitID: applicationCommitID})
+	err := qoveryAPIClient.DeployApplications(qoveryEnvironmentID, pkg.Applications{IDS: qoveryApplicationIDS, CommitID: applicationCommitID})
 	if err != nil {
 		return fmt.Errorf("error while trying to deploy application: %s", err)
 	}

--- a/github-action/main.go
+++ b/github-action/main.go
@@ -14,7 +14,7 @@ var (
 
 	qoveryOrganizationID = kingpin.Arg("qovery-org-id", "Qovery organization ID").Required().String()
 	qoveryEnvironmentID  = kingpin.Arg("qovery-env-id", "Qovery environment ID").Required().String()
-	qoveryApplicationID  = kingpin.Arg("qovery-app-id", "Qovery application ID").Required().String()
+	qoveryApplicationIDS = kingpin.Arg("qovery-app-id", "Qovery application ID").Required().String()
 	qoveryAPIToken       = kingpin.Arg("qovery-api-token", "Qovery API token").Required().String()
 	applicationCommitID  = kingpin.Arg("application-commit-id", "Application commit ID").String()
 )
@@ -35,7 +35,7 @@ func main() {
 
 	fmt.Printf("Qovery deployment starting for commit: %s ...\n", *applicationCommitID)
 
-	err := app.DeployApplication(*qoveryAPIToken, *qoveryApplicationID, *qoveryEnvironmentID, *applicationCommitID)
+	err := app.DeployApplication(*qoveryAPIToken, *qoveryApplicationIDS, *qoveryEnvironmentID, *applicationCommitID)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/github-action/pkg/models.go
+++ b/github-action/pkg/models.go
@@ -1,6 +1,6 @@
 package pkg
 
-type Application struct {
-	ID       string
+type Applications struct {
+	IDS       string
 	CommitID string
 }


### PR DESCRIPTION
This PR adds the ability to pass several application IDS to deploy.
It can be useful when using a monorepo.
New usage is:

```
on: [push]

jobs:
  deploy:
    runs-on: ubuntu-latest
    name: Deploy on Qovery
    steps:
      - name: Checkout
        uses: actions/checkout@v3
      - name: Deploy on Qovery
        uses: Qovery/qovery-action@main
        id: qovery
        with:
          qovery-organization-id: [YOUR_QOVERY_ORGANIZATION_ID]
          qovery-environment-id: [APPLICATION_QOVERY_ENVIRONMENT_ID]
          qovery-application-ids: [APPLICATION_QOVERY_APPLICATION_ID1,APPLICATION_QOVERY_APPLICATION_ID2]
          qovery-api-token: ${{secrets.QOVERY_API_TOKEN}}
```