### PR TITLE
Add a warning about multiple applications IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ jobs:
           qovery-api-token: ${{secrets.QOVERY_API_TOKEN}}
 ```
 
+> ⚠️ When passing several applications IDs, make sure all those applications are part of the GitHub repository the action will be running on. For applications in separate repositories, add a separate workflow in the relevant repo.
+
 ### Deploy a database
 
 ```


### PR DESCRIPTION
Adding multiple applications IDs can cause an issue if an application is not part of the same repository.
This PR adds a Warning to the README to make it clear.