### PR TITLE
fix OR condition on target deploy

### DIFF
--- a/github-action/main.go
+++ b/github-action/main.go
@@ -120,7 +120,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !deployApp && !deployDb {
+	if !deployApp || !deployDb {
 		fmt.Println("error: 'app-ids' or 'app-names' or 'db-id' or 'db-name' property must be defined.")
 		os.Exit(1)
 	}


### PR DESCRIPTION
The && condition forces the config to have an app-name AND a db-name, instead of one or the other as described in the error.